### PR TITLE
Fix market symbol split regexp.

### DIFF
--- a/bitshares/market.py
+++ b/bitshares/market.py
@@ -40,7 +40,7 @@ class Market(dict):
                   quote** and obtain/pay **only base**.
 
     """
-    market_sep_regex = "[/-:]"
+    market_sep_regex = "[/\-:]"
 
     def __init__(
         self,


### PR DESCRIPTION
Fix issue with asset names containing numbers like `BTS:BTSBOTS.S1`.
In the ASCII table, between '/' and ':' there is all the digits...

```
_get_assets_from_string(`BTS:BTSBOTS.S1`) = ['BTS', 'BTSBOTS.S', '']
```