### PR TITLE
pycryptodome & readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,27 @@
-Python Library for BitShares
-========================
+# Python Library for BitShares
 
-*placeholder*
+---
+
+## Documentation
+
+Visit the [pybitshares website](http://docs.pybitshares.com/en/latest/) for in depth documentation on this Python library.
+
+## Installation
+
+### Install with pip:
+```
+$ sudo apt-get install libffi-dev libssl-dev python-dev python-dev3
+$ pip3 install bitshares
+```
+
+### Manual installation:
+```
+$ git clone https://github.com/xeroc/python-bitshares/
+$ cd python-bitshares
+$ python3 setup.py install --user
+```
+
+### Upgrade
+```
+$ pip3 install --user --upgrade
+```

--- a/bitsharesbase/memo.py
+++ b/bitsharesbase/memo.py
@@ -4,7 +4,7 @@ from binascii import hexlify, unhexlify
 try:
     from Crypto.Cipher import AES
 except ImportError:
-    raise ImportError("Missing dependency: pycrypto")
+    raise ImportError("Missing dependency: pycryptodome")
 from .account import PrivateKey, PublicKey
 import struct
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 graphenelib
 bitshares
 autobahn>=0.14
-pycrypto==2.6.1
+pycryptodome==3.4.6
 appdirs==1.4.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 graphenelib
-pycrypto==2.6.1
+pycryptodome==3.4.6
 scrypt==0.7.1
 Events==0.2.2
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "appdirs",
         "Events",
         "scrypt",
-        "pycrypto",  # for AES, installed through graphenelib already
+        "pycryptodome",  # for AES, installed through graphenelib already
     ],
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],


### PR DESCRIPTION
Resubmitted PR https://github.com/xeroc/python-bitshares/pull/16

pycrypto has been depreciated & replaced with pycryptodome.

Updated the readme to include a link to the documentation & some basic install steps.

Relevant issue: https://github.com/xeroc/python-bitshares/issues/15